### PR TITLE
Chore: extends TextInput's ref

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -209,6 +209,7 @@ const PasteInput = forwardRef((props: PasteInputProps, ref) => {
             isFocused,
             focus: () => inputRef.current?.focus(),
             blur: () => inputRef.current?.blur(),
+            ...(inputRef.current || {}),
         }),
         [clear]
     );


### PR DESCRIPTION
For working with RN's method like `ReactNative.findNodeHandle`

