### PR TITLE
Fix use_frameworks!

### DIFF
--- a/ios/UIPasteboard+GetImageInfo.m
+++ b/ios/UIPasteboard+GetImageInfo.m
@@ -8,7 +8,11 @@
 
 #import "UIPasteboard+GetImageInfo.h"
 #import "NSData+MimeType.h"
+#if __has_include("react_native_paste_input/react_native_paste_input-Swift.h")
+#import "react_native_paste_input/react_native_paste_input-Swift.h"
+#else
 #import "react_native_paste_input-Swift.h"
+#endif
 #import "UIImage+vImageScaling.h"
 
 @implementation UIPasteboard (GetImageInfo)


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
If a project uses dynamic frameworks on iOS, projects that include this library will not compile. This PR fixes that issue.

#### Ticket Link
Fixes #22

