### PR TITLE
[GH-33] Prevent crash and restore functionality to Android on new-arch (when wrapping children)

### DIFF
--- a/src/PasteTextInput.tsx
+++ b/src/PasteTextInput.tsx
@@ -417,15 +417,11 @@ function InternalTextInput(props: PasteInputProps): React.ReactNode {
         />
     );
 
-    if (Platform.OS === 'ios') {
-        return (
-            <TextAncestor.Provider value={true}>
-                {textInput}
-            </TextAncestor.Provider>
-        );
-    }
-
-    return textInput;
+    return (
+        <TextAncestor.Provider value={true}>
+            {textInput}
+        </TextAncestor.Provider>
+    );
 }
 
 const enterKeyHintToReturnTypeMap: Record<string, ReturnKeyTypeOptions> = {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

This restores children-wrapping functionality to Android on RN's new arch (and stops a crash due to a "Unable to add a view into a view that is not a ViewGroup." error).  This use case was previously working on codebases using releases of `0.8.0` or `0.8.1` before the new arch migration (notably BlueSky as described in #33, and ours). 

First reported with a fix by @haileyok after the `0.8.0` release, but now validated to be a simple change with the `0.8.1` release. Also, tracing through history from the original RN `TextInput`, this wrapping should theoretically be able to exist for both iOS and Android.

In terms of testing, this change has been validated with `patch-package` to be working now for several weeks on iOS and Android (including on devices in production now) with our codebase.

#### Ticket Link

https://github.com/mattermost/react-native-paste-input/issues/33
