### PR TITLE
fix: eliminate scroll jitter in iOS text input when editing in upper …

### DIFF
--- a/ios/PasteTextInput.mm
+++ b/ios/PasteTextInput.mm
@@ -597,9 +597,18 @@ std::int32_t convertNSDictionaryValueToStdInt(NSDictionary *dictionary, NSString
   if ([self _textOf:attributedString equals:_backedTextInputView.attributedText]) {
     return;
   }
+  
+  // Save current scroll position
+  CGPoint originalOffset = _backedTextInputView.contentOffset;
+  
+  // Temporarily disable scrolling animations
+  BOOL originalScrollEnabled = _backedTextInputView.scrollEnabled;
+  _backedTextInputView.scrollEnabled = NO;
+  
   UITextRange *selectedRange = _backedTextInputView.selectedTextRange;
   NSInteger oldTextLength = _backedTextInputView.attributedText.string.length;
   _backedTextInputView.attributedText = attributedString;
+  
   if (selectedRange.empty) {
     // Maintaining a cursor position relative to the end of the old text.
     NSInteger offsetStart = [_backedTextInputView offsetFromPosition:_backedTextInputView.beginningOfDocument
@@ -612,6 +621,13 @@ std::int32_t convertNSDictionaryValueToStdInt(NSDictionary *dictionary, NSString
                                 notifyDelegate:YES];
   }
   [self _restoreTextSelection];
+  
+  // Restore scroll position immediately
+  [_backedTextInputView setContentOffset:originalOffset animated:NO];
+  
+  // Re-enable scrolling with original state
+  _backedTextInputView.scrollEnabled = originalScrollEnabled;
+  
   _lastStringStateWasUpdatedWith = attributedString;
 }
 


### PR DESCRIPTION
Fix: eliminate scroll jitter in iOS text input when editing in upper region

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

Resolved the iOS text input scroll jitter issue that occurs during upper region editing. The problem primarily affected components that render refined formatted text as children rather than via the value prop. When users edited text in the upper portion, the input field would maintain cursor position but inappropriately scroll to the bottom, creating a disruptive user experience.

The implementation addresses this by preserving the original content offset and temporarily disabling scrollability of the underlying _backedTextInputView instance during text manipulation. It restores the scrollEnabled property afterward, ensuring stable cursor positioning without compromising normal scrolling functionality.


#### Ticket Link

#42 
