### PR TITLE
fix: update PasteTextInput to use new property structure

### DIFF
--- a/ios/PasteTextInput.mm
+++ b/ios/PasteTextInput.mm
@@ -86,7 +86,7 @@ std::int32_t convertNSDictionaryValueToStdInt(NSDictionary *dictionary, NSString
     if (self = [super initWithFrame:frame]) {
         static const auto defaultProps = std::make_shared<const PasteTextInputProps>();
         _props = defaultProps;
-        
+
         _backedTextInputView = [[PasteInputTextView alloc] initWithFrame:self.bounds];
         _backedTextInputView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
         _backedTextInputView.textInputDelegate = self;
@@ -94,10 +94,10 @@ std::int32_t convertNSDictionaryValueToStdInt(NSDictionary *dictionary, NSString
         _ignoreNextTextInputCall = NO;
         _comingFromJS = NO;
         _didMoveToWindow = NO;
-        
+
         [self addSubview:_backedTextInputView];
     }
-    
+
     return self;
 }
 
@@ -122,8 +122,8 @@ std::int32_t convertNSDictionaryValueToStdInt(NSDictionary *dictionary, NSString
   const auto &newTextInputProps = static_cast<const PasteTextInputProps &>(*props);
 
   // Traits:
-  if (newTextInputProps.traits.multiline != oldTextInputProps.traits.multiline) {
-    [self _setMultiline:newTextInputProps.traits.multiline];
+  if (newTextInputProps.multiline != oldTextInputProps.multiline) {
+    [self _setMultiline:newTextInputProps.multiline];
   }
 
   if (newTextInputProps.traits.autocapitalizationType != oldTextInputProps.traits.autocapitalizationType) {
@@ -221,15 +221,15 @@ std::int32_t convertNSDictionaryValueToStdInt(NSDictionary *dictionary, NSString
   if (newTextInputProps.inputAccessoryViewID != oldTextInputProps.inputAccessoryViewID) {
     _backedTextInputView.inputAccessoryViewID = RCTNSStringFromString(newTextInputProps.inputAccessoryViewID);
   }
-    
+
   if (newTextInputProps.smartPunctuation != oldTextInputProps.smartPunctuation) {
       [self _setSmartPunctuation:[[NSString alloc] initWithCString:newTextInputProps.smartPunctuation.c_str() encoding:NSASCIIStringEncoding]];
   }
-    
+
   if (newTextInputProps.disableCopyPaste != oldTextInputProps.disableCopyPaste) {
     _backedTextInputView.disableCopyPaste = newTextInputProps.disableCopyPaste;
   }
-    
+
   [super updateProps:props oldProps:oldProps];
 
   [self setDefaultInputAccessoryView];
@@ -421,7 +421,7 @@ std::int32_t convertNSDictionaryValueToStdInt(NSDictionary *dictionary, NSString
     return;
   }
   const auto &props = static_cast<const PasteTextInputProps &>(*_props);
-  if (props.traits.multiline && ![_lastStringStateWasUpdatedWith isEqual:_backedTextInputView.attributedText]) {
+  if (props.multiline && ![_lastStringStateWasUpdatedWith isEqual:_backedTextInputView.attributedText]) {
     [self textInputDidChange];
     _ignoreNextTextInputCall = YES;
   }
@@ -636,7 +636,7 @@ std::int32_t convertNSDictionaryValueToStdInt(NSDictionary *dictionary, NSString
                     }
                 }
             }
-            
+
             eventEmitter->onPaste(PasteTextInputEventEmitter::OnPaste{
                 .data = eventDataVector
             });
@@ -708,11 +708,11 @@ std::int32_t convertNSDictionaryValueToStdInt(NSDictionary *dictionary, NSString
 - (SubmitBehavior)getSubmitBehavior
 {
   const auto &props = static_cast<const PasteTextInputProps &>(*_props);
-  const SubmitBehavior submitBehaviorDefaultable = props.traits.submitBehavior;
+  const SubmitBehavior submitBehaviorDefaultable = props.submitBehavior;
 
   // We should always have a non-default `submitBehavior`, but in case we don't, set it based on multiline.
   if (submitBehaviorDefaultable == SubmitBehavior::Default) {
-    return props.traits.multiline ? SubmitBehavior::Newline : SubmitBehavior::BlurAndSubmit;
+    return props.multiline ? SubmitBehavior::Newline : SubmitBehavior::BlurAndSubmit;
   }
 
   return submitBehaviorDefaultable;

--- a/ios/PasteTextInputSpecs/Props.cpp
+++ b/ios/PasteTextInputSpecs/Props.cpp
@@ -23,7 +23,7 @@ PasteTextInputProps::PasteTextInputProps(
     const PasteTextInputProps &sourceProps,
     const RawProps& rawProps)
     : ViewProps(context, sourceProps, rawProps),
-    BaseTextProps(context, sourceProps, rawProps),
+    : BaseTextInputProps(context, sourceProps, rawProps),
     traits(convertRawProp(context, rawProps, sourceProps.traits, {})),
     smartPunctuation(convertRawProp(context, rawProps, "smartPunctuation", sourceProps.smartPunctuation, {})),
     disableCopyPaste(convertRawProp(context, rawProps, "disableCopyPaste", sourceProps.disableCopyPaste, {false})),
@@ -119,7 +119,7 @@ TextAttributes PasteTextInputProps::getEffectiveTextAttributes(Float fontSizeMul
     auto result = TextAttributes::defaultTextAttributes();
     result.fontSizeMultiplier = fontSizeMultiplier;
     result.apply(textAttributes);
-                                                                   
+
     /*
     * These props are applied to `View`, therefore they must not be a part of
     * base text attributes.
@@ -132,11 +132,11 @@ TextAttributes PasteTextInputProps::getEffectiveTextAttributes(Float fontSizeMul
 
 ParagraphAttributes PasteTextInputProps::getEffectiveParagraphAttributes() const {
     auto result = paragraphAttributes;
-    
-    if (!traits.multiline) {
+
+    if (!multiline) {
         result.maximumNumberOfLines = 1;
     }
-    
+
     return result;
 }
 

--- a/ios/PasteTextInputSpecs/Props.cpp
+++ b/ios/PasteTextInputSpecs/Props.cpp
@@ -22,7 +22,6 @@ PasteTextInputProps::PasteTextInputProps(
     const PropsParserContext &context,
     const PasteTextInputProps &sourceProps,
     const RawProps& rawProps)
-    : ViewProps(context, sourceProps, rawProps),
     : BaseTextInputProps(context, sourceProps, rawProps),
     traits(convertRawProp(context, rawProps, sourceProps.traits, {})),
     smartPunctuation(convertRawProp(context, rawProps, "smartPunctuation", sourceProps.smartPunctuation, {})),

--- a/ios/PasteTextInputSpecs/Props.h
+++ b/ios/PasteTextInputSpecs/Props.h
@@ -15,6 +15,7 @@
 #include <react/renderer/components/iostextinput/conversions.h>
 #include <react/renderer/components/iostextinput/primitives.h>
 #include <react/renderer/components/text/BaseTextProps.h>
+#include <react/renderer/components/textinput/BaseTextInputProps.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/Props.h>
 #include <react/renderer/core/PropsParserContext.h>
@@ -25,17 +26,17 @@
 
 namespace facebook::react {
 
-class PasteTextInputProps final : public ViewProps, public BaseTextProps {
+class PasteTextInputProps final : public BaseTextInputProps {
 public:
     PasteTextInputProps() = default;
     PasteTextInputProps(const PropsParserContext& context, const PasteTextInputProps& sourceProps, const RawProps& rawProps);
-    
+
     void setProp(
                  const PropsParserContext& context,
                  RawPropsPropNameHash hash,
                  const char* propName,
                  const RawValue& value);
-    
+
 #pragma mark - Props
     const TextInputTraits traits{};
     const ParagraphAttributes paragraphAttributes{};
@@ -49,7 +50,7 @@ public:
 
     std::string smartPunctuation{};
     bool disableCopyPaste{false};
-    
+
     /*
      * Tint colors
      */


### PR DESCRIPTION
Summary

This PR updates the PasteTextInput native component to align with the architecture and API changes introduced in React Native 0.77.1.

Key updates:
	•	The multiline prop is now accessed directly on PasteTextInputProps, as the traits structure has been flattened in React Native 0.77.1.
	•	Removed legacy references to traits.multiline.
	•	Ensured compatibility with Fabric and proper state/prop updates under the new architecture.
