### PR TITLE
fix(android): attach missing events

### DIFF
--- a/android/src/main/java/com/mattermost/pasteinputtext/PasteTextInputManager.kt
+++ b/android/src/main/java/com/mattermost/pasteinputtext/PasteTextInputManager.kt
@@ -43,6 +43,16 @@ class PasteTextInputManager(context: ReactApplicationContext) : ReactTextInputMa
   override fun addEventEmitters(reactContext: ThemedReactContext, editText: ReactEditText) {
     super.addEventEmitters(reactContext, editText)
 
+    // ReactTextInputManager gates these listeners behind boolean @ReactProps
+    // (onSelectionChange, onContentSizeChange, onScroll, onKeyPress) that
+    // Fabric does not surface for codegen-based components. Attach them
+    // unconditionally — same as built-in <TextInput>, which always passes
+    // these handlers from JS regardless of whether the user provided one.
+    setOnSelectionChange(editText, true)
+    setOnContentSizeChange(editText, true)
+    setOnScroll(editText, true)
+    setOnKeyPress(editText, true)
+
     val pasteInputEditText = editText as PasteInputEditText
     val eventDispatcher = getEventDispatcher(reactContext, editText)
     pasteInputEditText.setOnPasteListener(PasteInputListener(pasteInputEditText, reactContext.surfaceId), eventDispatcher)


### PR DESCRIPTION
## Summary

Fixes `onSelectionChange`, `onContentSizeChange`, `onScroll`, and `onKeyPress` on Android Fabric — they were silently no-op for `<PasteTextInput>`.

## Root cause

`ReactTextInputManager` gates these four listeners behind boolean `@ReactProp`s (e.g. `setOnSelectionChange(view, true)` attaches the watcher). RN's built-in `<TextInput>` works because it ships a hand-written ViewConfig that lists these handlers as `validAttributes`, so React serializes them as boolean props when JS handlers are present.

Codegen-based components like `<PasteTextInput>` don't get that — the handlers are only registered as direct/bubbling events, never as attributes — so the Java setters never fire and the watchers stay unattached.

## Fix

In `PasteTextInputManager.addEventEmitters`, attach all four watchers unconditionally. This matches built-in `<TextInput>`'s actual behaviour: it always passes its internal `_onSelectionChange` to the native side regardless of whether the user provided a handler, so the watchers are effectively always-on there too.
