### PR TITLE
fix(ios): use findNodeHandle to register PasteInput on Fabric

### DIFF
--- a/src/PasteInput.tsx
+++ b/src/PasteInput.tsx
@@ -26,7 +26,12 @@ import React, {
     forwardRef,
     useImperativeHandle,
 } from 'react';
-import { Platform, TextInput, NativeEventEmitter } from 'react-native';
+import {
+    Platform,
+    TextInput,
+    NativeEventEmitter,
+    findNodeHandle,
+} from 'react-native';
 import type {
     PastedFile,
     PasteInputProps,
@@ -78,9 +83,14 @@ function PasteInputIOSComponent(
 
     // Register/unregister with native module on mount/unmount
     useEffect(() => {
-        // Get the native tag from the ref's internal __nativeTag property
-        // @ts-ignore - __nativeTag is an internal property
-        const nativeTag = textInputRef.current?.__nativeTag;
+        // Use findNodeHandle so we work across both legacy and Fabric. Reading
+        // `__nativeTag` directly returns undefined on RN 0.76+/Fabric — the
+        // renderer exposes the tag as `_nativeTag` (single underscore) on the
+        // Fabric instance — which silently breaks paste interception because
+        // the input is never registered with the native module. See #54.
+        const nativeTag = textInputRef.current
+            ? findNodeHandle(textInputRef.current)
+            : null;
 
         if (!nativeTag) {
             if (__DEV__) {


### PR DESCRIPTION
## Problem

On v2.0.0 / v2.0.1, the iOS paste interception silently fails to register on RN ≥ 0.76 with the New Architecture enabled. `onPaste` never fires; the Edit Menu / QuickType "Paste" / long-press Paste all fall through to the default `UITextView` paste handler, which does nothing for image-only clipboard contents — so to the user it looks like the library does nothing.

Filed as #54 with full repro details.

## Root cause

[`PasteInputIOSComponent`](https://github.com/mattermost/react-native-paste-input/blob/main/src/PasteInput.tsx#L83) reads the RN tag via the `__nativeTag` property (double underscore):

```ts
const nativeTag = textInputRef.current?.__nativeTag;
```

That property name is from the legacy renderer. Under Fabric (RN 0.76+ with `RCT_NEW_ARCH_ENABLED=1`), the renderer exposes the tag as `_nativeTag` (single underscore) on the Fabric instance — see e.g. `react-native@0.83.6` `Libraries/Renderer/implementations/ReactNativeRenderer-prod.js` ~line 1372:

```js
var tag = inst._nativeTag;
```

So `textInputRef.current?.__nativeTag` is `undefined`, the `useEffect` bails before calling `NativePasteInputModule.registerTextInput`, and the native module never attaches its `paste:` swizzle.

## Fix

Use [`findNodeHandle`](https://reactnative.dev/docs/findnodehandle) from `react-native`. It's the public API and resolves to the correct internal tag on both legacy and Fabric renderers.

```ts
import { findNodeHandle } from 'react-native';
// ...
const nativeTag = textInputRef.current
    ? findNodeHandle(textInputRef.current)
    : null;
```

## Repro

- RN 0.83.6 + Expo 55.0.16, `RCT_NEW_ARCH_ENABLED=1`
- `<PasteInput onPaste={...} />` focused
- Copy a PNG to the clipboard (host macOS → iOS Simulator works; pasteboard carries `public.png`)
- Tap system Paste affordance → no `onPaste` event before this change; works as expected after.

In `__DEV__`, the dev-only warning `[PasteInput] Could not get native tag from ref` fires once at mount before the fix and is silent after.

## Notes

- Behavior on the legacy renderer is unchanged: `findNodeHandle` still resolves to the same numeric tag.
- Only touches `src/PasteInput.tsx`. `tsc --noEmit` passes.
- The Android `PasteInputAndroidComponent` path is unaffected (it uses the custom `PasteTextInput` ComponentView and doesn't read the tag from JS).

Fixes #54